### PR TITLE
Pin guardian version to resolve compatibility issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 
 [project.optional-dependencies]
 guardian = [
-  "django-guardian==3.0.3",
+  "django-guardian==3.1.2",     # cannot be upgraded due to bug in get_objects_for_user
   "djangorestframework-guardian"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 
 [project.optional-dependencies]
 guardian = [
-  "django-guardian",
+  "django-guardian==3.0.3",
   "djangorestframework-guardian"
 ]
 


### PR DESCRIPTION
Pin the guardian dependency to the latest compatible version to avoid bugs with `get_objects_for_user`.