### PR TITLE
Batch permission resets + clean up permission utils

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,15 +1,8 @@
 {
     "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
     "python.terminal.activateEnvironment": true,
-    "python.testing.pytestEnabled": false,
-    "python.testing.unittestEnabled": true,
-    "python.testing.unittestArgs": [
-        // "--keepdb",
-        "-v",
-        "2",
-        // "-p",
-        // "test*.py"
-    ],
+    "python.testing.pytestEnabled": true,
+    "python.testing.unittestEnabled": false,
     "editor.formatOnSave": false,
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter",

--- a/permissible/models/role_based/core.py
+++ b/permissible/models/role_based/core.py
@@ -85,34 +85,40 @@ class PermDomain(BasePermDomain):
     def reset_domain_roles(self):
         """
         Create the associated `PermDomainRole` and `Group` objects for this
-        `PermDomain`.
+        `PermDomain`, then batch-reset all their permissions in a single call.
         """
         # Find the PermDomainRole model
         domain_role_model_class: Type[PermDomainRole] = (
             self.get_role_join_rel().related_model
         )
 
-        # print(f"Resetting permissions for PermDomain {self}")
-
         # Create/update PermDomainRole for each role in possible roles
         role_choices = domain_role_model_class._meta.get_field("role").choices
         domain_field = domain_role_model_class.get_domain_field()
         assert isinstance(role_choices, Iterable)
 
-        domain_role_objs_to_reset_perms = []
-        for role, _ in role_choices:
-            domain_role_obj, created = domain_role_model_class.objects.get_or_create(
-                role=role,
-                **{domain_field.attname: self.pk},
+        # 1 query: fetch existing roles
+        existing_roles_by_key = {
+            r.role: r
+            for r in domain_role_model_class.objects.filter(
+                **{domain_field.attname: self.pk}
             )
+        }
 
-            # Force reassigning of permissions if not a new PermDomainRole
-            if not created:
-                domain_role_obj: PermDomainRole
-                domain_role_objs_to_reset_perms.append(domain_role_obj)
+        # Build missing roles
+        new_role_objs = [
+            domain_role_model_class(role=role, **{domain_field.name: self})
+            for role, _ in role_choices
+            if role not in existing_roles_by_key
+        ]
 
-        # Perform reset
-        reset_permissions(domain_role_objs_to_reset_perms, clear_existing=False)
+        # N+1 queries: create Groups individually + bulk create PermDomainRoles
+        if new_role_objs:
+            domain_role_model_class.bulk_create_with_groups(new_role_objs)
+
+        # ~3 queries: single batched permission reset for all roles
+        all_domain_role_objs = list(existing_roles_by_key.values()) + new_role_objs
+        reset_permissions(all_domain_role_objs, clear_existing=False)
 
     def get_group_ids_for_roles(self, roles=None):
         domain_role_model_class: Type[PermDomainRole] = (
@@ -351,6 +357,21 @@ class PermDomainRole(
         reset_permissions([self])
 
         return super().save(*args, **kwargs)
+
+    @classmethod
+    def bulk_create_with_groups(cls, role_objs):
+        """
+        Bulk-create PermDomainRoles with their associated Groups.
+        Groups are created individually (need PKs for the OneToOneField),
+        then PermDomainRoles are bulk_created in a single query.
+
+        Does NOT call reset_permissions — the caller is responsible for that.
+        """
+        for role_obj in role_objs:
+            group = Group.objects.create(name=str(role_obj))
+            role_obj.group = group
+        if role_objs:
+            cls.objects.bulk_create(role_objs)
 
     @classmethod
     def get_domain_member_model_class(cls) -> Type[PermDomainMember]:

--- a/permissible/models/utils/__init__.py
+++ b/permissible/models/utils/__init__.py
@@ -1,4 +1,9 @@
 from .assign import *
 from .clear import *
-from .update import bulk_update_permissions_for_objects, ObjectGroupPermSpec
 from .reset import *
+
+# Exposed for tests — these are guardian-coupled internals
+from .update import guardian_bulk_update_permissions, ObjectGroupPermSpec
+
+# Backwards compatibility alias
+bulk_update_permissions_for_objects = guardian_bulk_update_permissions

--- a/permissible/models/utils/clear.py
+++ b/permissible/models/utils/clear.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 def clear_permissions_for_class(
     group: Group,
     obj_class: Type[PermissibleMixin],
-    skip_obj_ids: list[str] = [],
+    skip_obj_ids: list[str] | None = None,
 ):
     """
     Clear all object-level permissions for a class of objects.
@@ -23,21 +23,21 @@ def clear_permissions_for_class(
     )
     from permissible.signals import permissions_cleared
 
+    skip_obj_ids = skip_obj_ids or []
+
     # Retrieve all objects (of this class) that the group has permissions on
-    objs = get_objects_for_group(
-        group=group,
-        perms=[],
-        klass=obj_class,
-    ).exclude(id__in=skip_obj_ids)
+    objs = list(
+        get_objects_for_group(
+            group=group,
+            perms=[],
+            klass=obj_class,
+        ).exclude(id__in=skip_obj_ids)
+    )
 
-    # Get all relevant permissions for the object class
-    all_obj_class_perms = get_perms_for_model(obj_class)
-
-    # For each permission, remove all permissions for the group on all objects
-    for perm in all_obj_class_perms:
-        # remove_perm(perm, group, objs)      # TODO: doesnt work with MySQL
-        for obj in objs:
-            remove_perm(perm, group, obj)
+    # For each permission, bulk-remove across all objects
+    if objs:
+        for perm in get_perms_for_model(obj_class):
+            remove_perm(perm, group, objs)
 
     # Send signal (for logging, cache invalidation, etc)
     permissions_cleared.send(

--- a/permissible/models/utils/reset.py
+++ b/permissible/models/utils/reset.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from .clear import clear_permissions_for_class
-from .update import bulk_update_permissions_for_objects, ObjectGroupPermSpec
+from .update import guardian_bulk_update_permissions, ObjectGroupPermSpec
 
 if TYPE_CHECKING:
     from permissible.models.role_based.core import PermDomain, PermDomainRole
@@ -53,4 +53,15 @@ def reset_permissions(perm_domain_roles: list[PermDomainRole], clear_existing=Fa
 
     # Bulk update all permissions
     if specs:
-        bulk_update_permissions_for_objects(specs)
+        guardian_bulk_update_permissions(specs)
+
+    # Send signals (outside the bulk update's atomic block)
+    from permissible.signals import perm_domain_role_permissions_updated
+
+    for spec in specs:
+        perm_domain_role_permissions_updated.send(
+            sender=spec.obj.__class__,
+            obj=spec.obj,
+            group=spec.group,
+            short_perm_codes=spec.short_perm_codes,
+        )

--- a/permissible/models/utils/update.py
+++ b/permissible/models/utils/update.py
@@ -20,7 +20,7 @@ class ObjectGroupPermSpec:
     short_perm_codes: Sequence[str]
 
 
-def bulk_update_permissions_for_objects(
+def guardian_bulk_update_permissions(
     specs: Iterable[ObjectGroupPermSpec],
 ):
     """
@@ -161,22 +161,23 @@ def bulk_update_permissions_for_objects(
                         codename__in=all_add_codes,
                     )
                 }
-                
-                # Create any missing permissions
+
+                # Create any missing permissions (needed for dynamically-defined
+                # models where migrations haven't created the permissions yet)
                 missing_codes = all_add_codes - set(perms_by_code.keys())
                 if missing_codes:
-                    new_perms = []
-                    for code in missing_codes:
-                        # Create a readable permission name from the codename
-                        name = f"Can {code.replace('_', ' ')}"
-                        new_perms.append(Permission(
+                    logger.debug(
+                        "Creating missing permissions for %s: %s", ct, missing_codes
+                    )
+                    new_perms = [
+                        Permission(
                             content_type=ct,
                             codename=code,
-                            name=name,
-                        ))
+                            name=f"Can {code.replace('_', ' ')}",
+                        )
+                        for code in missing_codes
+                    ]
                     Permission.objects.bulk_create(new_perms, ignore_conflicts=True)
-                    
-                    # Refetch to get the IDs of newly created permissions
                     perms_by_code = {
                         p.codename: p
                         for p in Permission.objects.filter(
@@ -229,15 +230,3 @@ def bulk_update_permissions_for_objects(
             if to_delete_ids:
                 ObjPermModel.objects.filter(pk__in=to_delete_ids).delete()
 
-    # --- Signals outside the atomic block (semantics preserved) ---
-
-    from permissible.signals import perm_domain_role_permissions_updated
-
-    for Model, model_specs in specs_by_model.items():
-        for spec in model_specs:
-            perm_domain_role_permissions_updated.send(
-                sender=Model,
-                obj=spec.obj,
-                group=spec.group,
-                short_perm_codes=spec.short_perm_codes,
-            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 
 [project.optional-dependencies]
 guardian = [
-  "django-guardian==3.1.2",     # cannot be upgraded due to bug in get_objects_for_user
+  "django-guardian==3.3.1",     # can be upgraded
   "djangorestframework-guardian"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,14 @@ guardian = [
 [project.urls]
 Homepage = "https://github.com/gaussian/permissible"
 Issues = "https://github.com/gaussian/permissible/issues"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-django>=4.12.0",
+]
+
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "tests.settings"
+pythonpath = ["."]
+testpaths = ["tests"]

--- a/tests/integration/test_perm_domain_integration.py
+++ b/tests/integration/test_perm_domain_integration.py
@@ -22,6 +22,7 @@ from permissible.perm_def import p
 # Define domain models
 class TestIntegrationTeamModel(PermDomain):
     """A concrete PermDomain for testing"""
+    __test__ = False
 
     name = models.CharField(max_length=100)
     description = models.TextField(blank=True)
@@ -45,6 +46,7 @@ class TestIntegrationTeamModel(PermDomain):
 
 class TestTeamRole(PermDomainRole):
     """A concrete PermDomainRole for testing"""
+    __test__ = False
 
     team = models.ForeignKey(
         TestIntegrationTeamModel, on_delete=models.CASCADE, related_name="team_roles"
@@ -98,6 +100,7 @@ class TestTeamRole(PermDomainRole):
 
 class TestTeamMember(PermDomainMember):
     """A concrete PermDomainMember for testing"""
+    __test__ = False
 
     team = models.ForeignKey(
         TestIntegrationTeamModel, on_delete=models.CASCADE, related_name="team_members"
@@ -111,6 +114,7 @@ class TestTeamMember(PermDomainMember):
 # Test content model owned by a team
 class TestContent(PermissibleMixin, models.Model):
     """Content model owned by a team to test domain-based permissions"""
+    __test__ = False
 
     title = models.CharField(max_length=100)
     content = models.TextField()

--- a/tests/integration/test_permissible_filter_integration.py
+++ b/tests/integration/test_permissible_filter_integration.py
@@ -20,6 +20,7 @@ from permissible.models import PermissibleMixin, assign_short_perms
 
 # Define models for testing
 class TestFilterIntegrationModel(PermissibleMixin, models.Model):
+    __test__ = False
     name = models.CharField(max_length=100)
     is_public = models.BooleanField(default=False)
     status = models.CharField(max_length=20, default="active")

--- a/tests/integration/test_permissible_perms_integration.py
+++ b/tests/integration/test_permissible_perms_integration.py
@@ -23,6 +23,7 @@ from permissible.models import PermissibleMixin, assign_short_perms
 
 # Define models for testing
 class TestPermIntegrationModel(PermissibleMixin, models.Model):
+    __test__ = False
     name = models.CharField(max_length=100)
     is_public = models.BooleanField(default=False)
     owner = models.ForeignKey(get_user_model(), on_delete=models.CASCADE, null=True)
@@ -58,6 +59,7 @@ class TestPermIntegrationModel(PermissibleMixin, models.Model):
 
 # Serializer for TestModel
 class TestModelSerializer(serializers.ModelSerializer):
+    __test__ = False
     class Meta:
         model = TestPermIntegrationModel
         fields = ["id", "name", "is_public", "owner"]
@@ -65,6 +67,7 @@ class TestModelSerializer(serializers.ModelSerializer):
 
 # ViewSet for testing
 class TestModelViewSet(ModelViewSet):
+    __test__ = False
     queryset = TestPermIntegrationModel.objects.all()
     serializer_class = TestModelSerializer
     permission_classes = [PermissiblePerms]

--- a/tests/test_bulk_update_permissions.py
+++ b/tests/test_bulk_update_permissions.py
@@ -1,16 +1,20 @@
 """
 Tests for bulk_update_permissions_for_objects function.
 """
+from unittest.mock import patch, call
+
 from django.test import TestCase
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
-from guardian.shortcuts import get_group_perms
+from guardian.shortcuts import assign_perm, get_group_perms
 
 from permissible.models import PermDomain, PermDomainRole, PermDomainMember
 from permissible.models.utils import bulk_update_permissions_for_objects, ObjectGroupPermSpec
+from permissible.models.utils.clear import clear_permissions_for_class
+from permissible.models.utils.reset import reset_permissions
 
 
 # Dummy concrete models for testing (renamed to avoid conflicts)
@@ -374,3 +378,112 @@ class BulkUpdatePermissionsTests(TestCase):
             ["view", "change"], include_app_label=False
         )
         self.assertEqual(set(perms), expected_perms)
+
+
+class SignalTests(TestCase):
+    """Tests that permission signals fire correctly."""
+
+    def setUp(self):
+        BulkTestDomainRole.objects.all().delete()
+        Group.objects.all().delete()
+        BulkTestDomain.objects.all().delete()
+
+    def test_reset_permissions_sends_signal_per_target(self):
+        """reset_permissions should send perm_domain_role_permissions_updated for each target."""
+        domain = BulkTestDomain.objects.create(name="Signal Test Domain")
+        group = Group.objects.create(name="Signal Test Group")
+        role = BulkTestDomainRole.objects.create(
+            role="view", group=group, bulktestdomain=domain
+        )
+
+        with patch(
+            "permissible.signals.perm_domain_role_permissions_updated.send"
+        ) as mock_send:
+            reset_permissions([role])
+
+        mock_send.assert_called_once()
+        _, kwargs = mock_send.call_args
+        self.assertEqual(kwargs["sender"], BulkTestDomain)
+        self.assertEqual(kwargs["obj"].pk, domain.pk)
+        self.assertEqual(kwargs["group"], group)
+        self.assertEqual(kwargs["short_perm_codes"], ["view"])
+
+    def test_reset_permissions_sends_signal_for_multiple_roles(self):
+        """reset_permissions with multiple roles sends one signal per (role, target)."""
+        domain = BulkTestDomain.objects.create(name="Multi Signal Domain")
+        group1 = Group.objects.create(name="Multi Signal Group 1")
+        group2 = Group.objects.create(name="Multi Signal Group 2")
+        role1 = BulkTestDomainRole.objects.create(
+            role="view", group=group1, bulktestdomain=domain
+        )
+        role2 = BulkTestDomainRole.objects.create(
+            role="con", group=group2, bulktestdomain=domain
+        )
+
+        with patch(
+            "permissible.signals.perm_domain_role_permissions_updated.send"
+        ) as mock_send:
+            reset_permissions([role1, role2])
+
+        self.assertEqual(mock_send.call_count, 2)
+
+
+class ClearPermissionsTests(TestCase):
+    """Tests for clear_permissions_for_class."""
+
+    def setUp(self):
+        BulkTestDomainRole.objects.all().delete()
+        Group.objects.all().delete()
+        BulkTestDomain.objects.all().delete()
+
+    def test_clear_removes_all_permissions(self):
+        """clear_permissions_for_class removes all permissions for a group on a class."""
+        domain = BulkTestDomain.objects.create(name="Clear Test Domain")
+        group = Group.objects.create(name="Clear Test Group")
+
+        # Assign some permissions
+        specs = [
+            ObjectGroupPermSpec(
+                obj=domain, group=group, short_perm_codes=["view", "change"]
+            )
+        ]
+        bulk_update_permissions_for_objects(specs)
+        self.assertTrue(len(get_group_perms(group, domain)) > 0)
+
+        # Clear
+        clear_permissions_for_class(group=group, obj_class=BulkTestDomain)
+
+        # Verify all gone
+        self.assertEqual(len(get_group_perms(group, domain)), 0)
+
+    def test_clear_sends_signal(self):
+        """clear_permissions_for_class sends permissions_cleared signal."""
+        domain = BulkTestDomain.objects.create(name="Clear Signal Domain")
+        group = Group.objects.create(name="Clear Signal Group")
+
+        with patch("permissible.signals.permissions_cleared.send") as mock_send:
+            clear_permissions_for_class(group=group, obj_class=BulkTestDomain)
+
+        mock_send.assert_called_once_with(sender=BulkTestDomain, group=group)
+
+    def test_clear_respects_skip_obj_ids(self):
+        """clear_permissions_for_class skips objects in skip_obj_ids."""
+        domain1 = BulkTestDomain.objects.create(name="Clear Skip Domain 1")
+        domain2 = BulkTestDomain.objects.create(name="Clear Skip Domain 2")
+        group = Group.objects.create(name="Clear Skip Group")
+
+        # Assign perms to both domains
+        specs = [
+            ObjectGroupPermSpec(obj=domain1, group=group, short_perm_codes=["view"]),
+            ObjectGroupPermSpec(obj=domain2, group=group, short_perm_codes=["view"]),
+        ]
+        bulk_update_permissions_for_objects(specs)
+
+        # Clear but skip domain1
+        clear_permissions_for_class(
+            group=group, obj_class=BulkTestDomain, skip_obj_ids=[str(domain1.pk)]
+        )
+
+        # domain1 should still have perms, domain2 should not
+        self.assertTrue(len(get_group_perms(group, domain1)) > 0)
+        self.assertEqual(len(get_group_perms(group, domain2)), 0)

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -18,6 +18,7 @@ from permissible.models import PermissibleMixin
 
 # Define a test model
 class TestLoggingModel(PermissibleMixin, models.Model):
+    __test__ = False
     name = models.CharField(max_length=100)
 
     class Meta:
@@ -36,6 +37,7 @@ class TestLoggingModel(PermissibleMixin, models.Model):
 
 
 class TestLoggingViewSet(ModelViewSet):
+    __test__ = False
     queryset = TestLoggingModel.objects.all()
     permission_classes = [PermissiblePerms]
     filter_backends = [PermissibleFilter]

--- a/tests/test_perm_domain.py
+++ b/tests/test_perm_domain.py
@@ -488,5 +488,119 @@ class PermDomainTests(TestCase):
         self.assertTrue(result, "Direct condition check should pass with matching ID")
 
 
+    def test_reset_domain_roles_bulk_create_group_pks(self):
+        """
+        Regression test: bulk_create of PermDomainRoles must not reference
+        unsaved Group objects. On MySQL, Group.objects.bulk_create() does not
+        set PKs on the returned objects, so assigning group=<unsaved Group>
+        then calling bulk_create on PermDomainRoles raises ValueError.
+
+        We simulate the MySQL behaviour by patching bulk_create to not set PKs.
+        """
+        DummyDomainRole.objects.all().delete()
+        Group.objects.all().delete()
+        DummyDomain.objects.all().delete()
+
+        original_bulk_create = Group.objects.bulk_create.__func__
+
+        def bulk_create_without_pks(manager, objs, *args, **kwargs):
+            """Simulate MySQL: bulk_create saves rows but doesn't set PKs."""
+            result = original_bulk_create(manager, objs, *args, **kwargs)
+            for obj in result:
+                obj.pk = None
+                obj.id = None
+            return result
+
+        with patch.object(
+            type(Group.objects), "bulk_create", bulk_create_without_pks
+        ):
+            # This should NOT raise ValueError about unsaved related objects
+            domain = DummyDomain.objects.create(
+                name="Bulk Create PK Test Domain"
+            )
+
+        # Verify roles were created correctly
+        role_choices = list(DummyDomainRole._meta.get_field("role").choices)
+        roles_qs = DummyDomainRole.objects.filter(dummydomain=domain)
+        self.assertEqual(roles_qs.count(), len(role_choices))
+
+        for role_obj in roles_qs:
+            self.assertTrue(
+                Group.objects.filter(pk=role_obj.group_id).exists(),
+                f"Group for role {role_obj.role} should exist in DB",
+            )
+
+    def test_reset_domain_roles_full_path(self):
+        """
+        Test that reset_domain_roles creates Groups, PermDomainRoles, and
+        assigns permissions in a single batched call — without mocking
+        reset_permissions. This exercises the full bulk_create path.
+        """
+        from guardian.shortcuts import get_group_perms
+
+        DummyDomainRole.objects.all().delete()
+        Group.objects.all().delete()
+        DummyDomain.objects.all().delete()
+
+        # Create domain — triggers reset_domain_roles via save()
+        domain = DummyDomain.objects.create(name="Full Path Test Domain")
+
+        # Verify all roles were created
+        role_choices = list(DummyDomainRole._meta.get_field("role").choices)
+        roles_qs = DummyDomainRole.objects.filter(dummydomain=domain)
+        self.assertEqual(roles_qs.count(), len(role_choices))
+
+        # Verify each role has a saved Group with a valid PK
+        for role_obj in roles_qs:
+            self.assertIsNotNone(role_obj.group_id)
+            self.assertTrue(
+                Group.objects.filter(pk=role_obj.group_id).exists(),
+                f"Group for role {role_obj.role} should exist in DB",
+            )
+
+        # Verify permissions were actually assigned per ROLE_DEFINITIONS
+        for role_obj in roles_qs:
+            _, short_perm_codes = DummyDomainRole.ROLE_DEFINITIONS[role_obj.role]
+            expected = DummyDomain.get_permission_codenames(
+                short_perm_codes, include_app_label=False
+            )
+            actual = set(get_group_perms(role_obj.group, domain))
+            self.assertEqual(
+                expected,
+                actual,
+                f"Permissions mismatch for role {role_obj.role}: "
+                f"expected {expected}, got {actual}",
+            )
+
+    def test_reset_domain_roles_idempotent(self):
+        """
+        Calling reset_domain_roles twice should not fail or create duplicates.
+        """
+        from guardian.shortcuts import get_group_perms
+
+        DummyDomainRole.objects.all().delete()
+        Group.objects.all().delete()
+        DummyDomain.objects.all().delete()
+
+        domain = DummyDomain.objects.create(name="Idempotent Test Domain")
+        role_choices = list(DummyDomainRole._meta.get_field("role").choices)
+
+        # Call reset_domain_roles again
+        domain.reset_domain_roles()
+
+        # Still the same number of roles
+        roles_qs = DummyDomainRole.objects.filter(dummydomain=domain)
+        self.assertEqual(roles_qs.count(), len(role_choices))
+
+        # Permissions still correct
+        for role_obj in roles_qs:
+            _, short_perm_codes = DummyDomainRole.ROLE_DEFINITIONS[role_obj.role]
+            expected = DummyDomain.get_permission_codenames(
+                short_perm_codes, include_app_label=False
+            )
+            actual = set(get_group_perms(role_obj.group, domain))
+            self.assertEqual(expected, actual)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_permissible_mixin.py
+++ b/tests/test_permissible_mixin.py
@@ -103,6 +103,7 @@ class MockUser:
 
 # Create test models that use PermissibleMixin
 class TestModel(PermissibleMixin, models.Model):
+    __test__ = False
     name = models.CharField(max_length=100)
 
     # Store policies locally for the mock to use

--- a/uv.lock
+++ b/uv.lock
@@ -93,7 +93,7 @@ wheels = [
 
 [[package]]
 name = "permissible"
-version = "0.7.14"
+version = "0.7.15"
 source = { editable = "." }
 dependencies = [
     { name = "django" },

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "django"
 version = "5.2.13"
 source = { registry = "https://pypi.org/simple" }
@@ -65,6 +74,24 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
 name = "permissible"
 version = "0.7.14"
 source = { editable = "." }
@@ -79,6 +106,12 @@ guardian = [
     { name = "djangorestframework-guardian" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-django" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=5.2.13,<6" },
@@ -87,6 +120,58 @@ requires-dist = [
     { name = "djangorestframework-guardian", marker = "extra == 'guardian'" },
 ]
 provides-extras = ["guardian"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-django", specifier = ">=4.12.0" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-django"
+version = "4.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/2b/db9a193df89e5660137f5428063bcc2ced7ad790003b26974adf5c5ceb3b/pytest_django-4.12.0.tar.gz", hash = "sha256:df94ec819a83c8979c8f6de13d9cdfbe76e8c21d39473cfe2b40c9fc9be3c758", size = 91156, upload-time = "2026-02-14T18:40:49.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/a5/41d091f697c09609e7ef1d5d61925494e0454ebf51de7de05f0f0a728f1d/pytest_django-4.12.0-py3-none-any.whl", hash = "sha256:3ff300c49f8350ba2953b90297d23bf5f589db69545f56f1ec5f8cff5da83e85", size = 26123, upload-time = "2026-02-14T18:40:47.381Z" },
+]
 
 [[package]]
 name = "sqlparse"

--- a/uv.lock
+++ b/uv.lock
@@ -27,15 +27,15 @@ wheels = [
 
 [[package]]
 name = "django-guardian"
-version = "3.1.2"
+version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/ac/5a8f7301c0181ee9020e020a4fa519f9851726b8fd3c1177656c1f5a1be0/django_guardian-3.1.2.tar.gz", hash = "sha256:6fc93b55e5eacd1a062a959c5578b433d999a286742aa3e7e713c71046813538", size = 93422, upload-time = "2025-09-08T15:43:51.361Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/9a/e332f886bc38dd8bb7b0cdf7305d8dcf6acc376459b87b1ce73697666d55/django_guardian-3.3.1.tar.gz", hash = "sha256:7a50eada72161e355a9dbf9fe0838855c0ec851dd9b39f4f16e2decb5f4c7988", size = 109557, upload-time = "2026-03-30T09:44:59.008Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/50/3a4a891f809c9865d30864f59f993f9535b18e3935dfad278c9682fc537f/django_guardian-3.1.2-py3-none-any.whl", hash = "sha256:6c10f88d0b7efd171ae65d7ac487a666f41eb373c6f94d80016b1a19bdfbf212", size = 127451, upload-time = "2025-09-08T15:43:49.987Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4f/f798f8a2cb2f84def1fd2bf38f497c45a2ebd093f6bdb1f349eb52faa466/django_guardian-3.3.1-py3-none-any.whl", hash = "sha256:2a3a4b94cdc7e8fc99b74eef163db69d17703dc397c3e9085c7231f2b2bcf431", size = 146125, upload-time = "2026-03-30T09:44:57.599Z" },
 ]
 
 [[package]]
@@ -66,7 +66,7 @@ wheels = [
 
 [[package]]
 name = "permissible"
-version = "0.7.13"
+version = "0.7.14"
 source = { editable = "." }
 dependencies = [
     { name = "django" },
@@ -82,7 +82,7 @@ guardian = [
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=5.2.13,<6" },
-    { name = "django-guardian", marker = "extra == 'guardian'", specifier = "==3.1.2" },
+    { name = "django-guardian", marker = "extra == 'guardian'", specifier = "==3.3.1" },
     { name = "djangorestframework", specifier = ">=3" },
     { name = "djangorestframework-guardian", marker = "extra == 'guardian'" },
 ]


### PR DESCRIPTION
## Summary

- **Upgrade django-guardian** from 3.1.2 to 3.3.1
- **Switch test runner** from unittest to pytest with pytest-django
- **Batch permission resets in `reset_domain_roles`** — ~10 queries down from ~30 per new domain. Adds `PermDomainRole.bulk_create_with_groups()` classmethod, refactors `reset_domain_roles()` to fetch existing roles in 1 query, bulk-create missing ones, then call `reset_permissions` once
- **Clean up permission utils** — rename `bulk_update_permissions_for_objects` → `guardian_bulk_update_permissions` to make guardian coupling explicit, move signal-sending from `update.py` to `reset.py`, fix `clear.py` to use bulk `remove_perm` (guardian 3.3.1), fix mutable default arg
- **Add tests** for signal-sending, `clear_permissions_for_class`, MySQL `bulk_create` regression, full-path `reset_domain_roles`, idempotency

## Test plan

- [x] All 145 tests pass (`uv run pytest tests/ -v`)
- [ ] Verify downstream (neutron) test suite passes with updated permissible

🤖 Generated with [Claude Code](https://claude.com/claude-code)