### PR TITLE
Deny and log when action is None in permission checks

### DIFF
--- a/permissible/models/permissible_mixin.py
+++ b/permissible/models/permissible_mixin.py
@@ -5,6 +5,7 @@ Author: Kut Akdogan & Gaussian Holdings, LLC. (2016-)
 
 from __future__ import annotations
 
+import logging
 from typing import Type, Optional
 
 from django.contrib.auth.models import PermissionsMixin
@@ -12,6 +13,8 @@ from django.contrib.auth.models import PermissionsMixin
 from permissible.perm_def import BasePermDefObj, BasePermDef
 
 from .policy_lookup import PolicyLooupMixin
+
+logger = logging.getLogger(__name__)
 
 
 class PermissibleMixin(PolicyLooupMixin, BasePermDefObj):
@@ -129,6 +132,14 @@ class PermissibleMixin(PolicyLooupMixin, BasePermDefObj):
         :return:
         """
 
+        if action is None:
+            logger.warning(
+                "has_global_permission called with action=None for %s — denying. "
+                "This usually means the caller did not resolve an action.",
+                cls,
+            )
+            return False
+
         # Superusers override
         if user and user.is_superuser:
             return True
@@ -178,6 +189,14 @@ class PermissibleMixin(PolicyLooupMixin, BasePermDefObj):
         :param context:
         :return:
         """
+
+        if action is None:
+            logger.warning(
+                "has_object_permission called with action=None for %s — denying. "
+                "This usually means the caller did not resolve an action.",
+                self.__class__,
+            )
+            return False
 
         # Superusers override
         if user and user.is_superuser:

--- a/tests/test_permissible_mixin.py
+++ b/tests/test_permissible_mixin.py
@@ -269,6 +269,29 @@ class TestPermissibleMixin(unittest.TestCase):
             )
 
     @patch("permissible.models.permissible_mixin.PolicyLooupMixin.get_policies")
+    def test_none_action_denies_and_logs(self, mock_get_policies):
+        """action=None should deny (not raise) and log a warning."""
+        mock_get_policies.return_value = self.test_model._policies
+
+        with self.assertLogs(
+            "permissible.models.permissible_mixin", level="WARNING"
+        ) as cm:
+            self.assertFalse(
+                TestModel.has_global_permission(self.superuser, None),
+                "action=None should deny even for superusers",
+            )
+        self.assertTrue(any("action=None" in msg for msg in cm.output))
+
+        with self.assertLogs(
+            "permissible.models.permissible_mixin", level="WARNING"
+        ) as cm:
+            self.assertFalse(
+                self.test_model.has_object_permission(self.superuser, None),
+                "action=None should deny even for superusers",
+            )
+        self.assertTrue(any("action=None" in msg for msg in cm.output))
+
+    @patch("permissible.models.permissible_mixin.PolicyLooupMixin.get_policies")
     def test_object_permissions_view_only(self, mock_get_policies):
         """Test that view-only users have appropriate object permissions"""
         mock_get_policies.return_value = self.test_model._policies


### PR DESCRIPTION
## Summary
- `has_global_permission` / `has_object_permission` now return `False` with a `logger.warning` when `action is None`, instead of tripping the "no policy defined" assert (which surfaced as a 500).
- Callers like DRF can pass `view.action=None` for unresolved methods (e.g. OPTIONS), which isn't a config bug and shouldn't crash.

## Test plan
- [x] `tests/test_permissible_mixin.py::test_none_action_denies_and_logs` — verifies both methods deny and emit a warning on the `permissible.models.permissible_mixin` logger, even for superusers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)