### PR TITLE
fix(permissions): short-circuit _ignore_model_permissions before _queryset

### DIFF
--- a/permissible/permissions.py
+++ b/permissible/permissions.py
@@ -47,6 +47,12 @@ class PermissiblePerms(CheckViewConfigMixin, permissions.DjangoModelPermissions)
         be granted.
         """
 
+        # Workaround to ensure DjangoModelPermissions are not applied to the
+        # root view when using DefaultRouter. Must run before `_queryset()`,
+        # which asserts the view has a queryset (APIRootView has none).
+        if getattr(view, "_ignore_model_permissions", False):
+            return True
+
         # We require PermissibleFilter to be used on the view
         queryset = self._queryset(view)
         self._check_view_config(view, queryset)
@@ -54,11 +60,6 @@ class PermissiblePerms(CheckViewConfigMixin, permissions.DjangoModelPermissions)
         assert getattr(
             request, "user", None
         ), "User object must be available in request for PermissiblePerms"
-
-        # Workaround to ensure DjangoModelPermissions are not applied
-        # to the root view when using DefaultRouter.
-        if getattr(view, "_ignore_model_permissions", False):
-            return True
 
         model_class: Type[PermissibleMixin] = queryset.model
         perm_check_kwargs = {

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -144,6 +144,20 @@ class TestPermissiblePerms(unittest.TestCase):
         result = perms.has_permission(request, view)
         self.assertTrue(result)
 
+    def test_ignore_model_permissions_without_queryset(self):
+        # Regression: the DefaultRouter root (APIRootView) sets
+        # `_ignore_model_permissions` and has no queryset/get_queryset. The
+        # short-circuit must run before the real `_queryset()`, which would
+        # otherwise AssertionError (the prod GET /api/v1/ 500). Note we use a
+        # real PermissiblePerms here, NOT get_permission_instance, which
+        # monkey-patches `_queryset` away and hides the bug.
+        class RootView:
+            _ignore_model_permissions = True  # no queryset / get_queryset
+
+        request = DummyRequest(user=DummyUser())
+        perms = PermissiblePerms()
+        self.assertTrue(perms.has_permission(request, RootView()))
+
     def test_global_permission_false(self):
         # Authenticated user but global permission check fails should return False.
         DummyModel.global_permission = False

--- a/uv.lock
+++ b/uv.lock
@@ -93,7 +93,7 @@ wheels = [
 
 [[package]]
 name = "permissible"
-version = "0.7.15"
+version = "0.7.17"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
## Problem

`PermissiblePerms.has_permission` called `self._queryset(view)` **before** checking `view._ignore_model_permissions`. The DRF `DefaultRouter` root (`APIRootView`) has no queryset and relies on that flag to be skipped, so `_queryset()`'s assertion raised:

```
AssertionError: Cannot apply PermissiblePerms on a view that does not set `.queryset` or have a `.get_queryset()` method.
```

This surfaced in production as a 500 on `GET /api/v1/` (hit by a vulnerability scanner following the `/api/v1` → `/api/v1/` redirect).

## Fix

Reorder `has_permission` so the `_ignore_model_permissions` short-circuit runs first — matching DRF's own `DjangoModelPermissions.has_permission` ordering.

## Test

Added `test_ignore_model_permissions_without_queryset`, using a queryset-less root view and the **real** `_queryset` (the existing test monkey-patched `_queryset` away, which is why the bug slipped through). Verified it fails with the exact prod `AssertionError` without the fix and passes with it. Full suite: 147 passed.