### PR TITLE
fix(permissions): deny (not 500) on DRF implicit "metadata"/OPTIONS action

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,27 @@ ACTION_POLICIES = {
 }
 ```
 
+Every action must have an explicit policy — if a request resolves to an action
+with no policy defined, permission is denied and an assertion is raised (a
+deliberate guardrail against forgetting to configure an action).
+
+The one exception is DRF's implicit `"metadata"` action, which DRF sets for
+every `OPTIONS` request on every ViewSet. It never corresponds to a policy, so
+it is **denied by default** (returning `403`, and logging a warning) rather than
+raising. If you want `OPTIONS`/introspection to work for a model, opt in by
+defining an explicit `"metadata"` policy for it, e.g.:
+```
+ACTION_POLICIES = {
+    "surveys.Survey": {
+        "global": {
+            ...
+            "metadata": NO_RESTRICTION,  # or IS_AUTHENTICATED, etc.
+        },
+        ...
+    }
+}
+```
+
 With the permissions configured, now we can force different views to use them:
 - If you would like the permissions to work for API views (via
 `django-rest-framework`): Add `PermissiblePerms` to the `permission_classes` for

--- a/permissible/models/permissible_mixin.py
+++ b/permissible/models/permissible_mixin.py
@@ -17,6 +17,12 @@ from .policy_lookup import PolicyLooupMixin
 logger = logging.getLogger(__name__)
 
 
+# DRF sets `view.action = "metadata"` for every OPTIONS request (see
+# ViewSetMixin.initialize_request). Such implicit actions never have a policy, so
+# a missing one must deny cleanly rather than trip the assertion below (a 500).
+DRF_IMPLICIT_ACTIONS = frozenset({"metadata"})
+
+
 class PermissibleMixin(PolicyLooupMixin, BasePermDefObj):
     """
     Model mixin that allows a model to check permissions, in accordance with
@@ -151,9 +157,20 @@ class PermissibleMixin(PolicyLooupMixin, BasePermDefObj):
             perm_def = cls.get_global_perms_def("retrieve")
 
         # Deny if no EXPLICIT permission check is defined
-        assert (
-            perm_def is not None
-        ), f"No global permission defined for {cls} action '{action}' in `policies.ACTION_POLICIES`"
+        if perm_def is None:
+            if action in DRF_IMPLICIT_ACTIONS:
+                logger.warning(
+                    "Denying implicit DRF action '%s' for %s (no policy defined; "
+                    "add one to ACTION_POLICIES to override).",
+                    action,
+                    cls,
+                )
+                return False
+
+            raise AssertionError(
+                f"No global permission defined for {cls} action '{action}' in "
+                f"`policies.ACTION_POLICIES`"
+            )
 
         # Check permissions on the class
         return perm_def.check_global(
@@ -204,9 +221,20 @@ class PermissibleMixin(PolicyLooupMixin, BasePermDefObj):
 
         # Get the PermDef for this action (object permissions)
         perm_def = self.get_object_perm_def(action)
-        assert (
-            perm_def is not None
-        ), f"No object permission for {self.__class__.__name__} (action '{action}') in `policies.ACTION_POLICIES`"
+        if perm_def is None:
+            if action in DRF_IMPLICIT_ACTIONS:
+                logger.warning(
+                    "Denying implicit DRF action '%s' for %s (no policy defined; "
+                    "add one to ACTION_POLICIES to override).",
+                    action,
+                    self.__class__,
+                )
+                return False
+
+            raise AssertionError(
+                f"No object permission for {self.__class__.__name__} "
+                f"(action '{action}') in `policies.ACTION_POLICIES`"
+            )
 
         # Check permissions on the object
         return perm_def.check_obj(

--- a/tests/test_permissible_mixin.py
+++ b/tests/test_permissible_mixin.py
@@ -292,6 +292,64 @@ class TestPermissibleMixin(unittest.TestCase):
         self.assertTrue(any("action=None" in msg for msg in cm.output))
 
     @patch("permissible.models.permissible_mixin.PolicyLooupMixin.get_policies")
+    def test_metadata_action_denies_and_logs(self, mock_get_policies):
+        """DRF's implicit "metadata" (OPTIONS) action denies + logs, not raises."""
+        mock_get_policies.return_value = self.test_model._policies
+
+        with self.assertLogs(
+            "permissible.models.permissible_mixin", level="WARNING"
+        ) as cm:
+            self.assertFalse(
+                TestModel.has_global_permission(self.view_user, "metadata"),
+                "metadata (OPTIONS) should deny, not raise",
+            )
+        self.assertTrue(any("metadata" in msg for msg in cm.output))
+
+        with self.assertLogs(
+            "permissible.models.permissible_mixin", level="WARNING"
+        ) as cm:
+            self.assertFalse(
+                self.test_model.has_object_permission(self.view_user, "metadata"),
+                "metadata (OPTIONS) should deny, not raise",
+            )
+        self.assertTrue(any("metadata" in msg for msg in cm.output))
+
+    @patch("permissible.models.permissible_mixin.PolicyLooupMixin.get_policies")
+    def test_unknown_action_still_raises(self, mock_get_policies):
+        """A non-implicit action with no policy still raises (the guardrail)."""
+        mock_get_policies.return_value = self.test_model._policies
+
+        with self.assertRaises(AssertionError):
+            TestModel.has_global_permission(self.view_user, "some_custom_action")
+
+        with self.assertRaises(AssertionError):
+            self.test_model.has_object_permission(self.view_user, "some_custom_action")
+
+    @patch("permissible.models.permissible_mixin.PolicyLooupMixin.get_policies")
+    def test_metadata_action_honors_explicit_policy(self, mock_get_policies):
+        """An explicit "metadata" policy wins over the deny-by-default carve-out."""
+        policies = {
+            "global": {**self.test_model._policies["global"], "metadata": p(["view"])},
+            "object": {**self.test_model._policies["object"], "metadata": p(["view"])},
+        }
+        mock_get_policies.return_value = policies
+
+        self.assertTrue(
+            TestModel.has_global_permission(self.view_user, "metadata"),
+            "An explicit metadata policy should be honored",
+        )
+
+    @patch("permissible.models.permissible_mixin.PolicyLooupMixin.get_policies")
+    def test_metadata_action_superuser(self, mock_get_policies):
+        """Superusers short-circuit before the policy lookup, even for metadata."""
+        mock_get_policies.return_value = self.test_model._policies
+
+        self.assertTrue(
+            TestModel.has_global_permission(self.superuser, "metadata"),
+            "Superuser should pass the metadata action",
+        )
+
+    @patch("permissible.models.permissible_mixin.PolicyLooupMixin.get_policies")
     def test_object_permissions_view_only(self, mock_get_policies):
         """Test that view-only users have appropriate object permissions"""
         mock_get_policies.return_value = self.test_model._policies


### PR DESCRIPTION
## Problem

`OPTIONS` requests to any `permissible`-protected viewset were returning **500** in production:

```
AssertionError: No global permission defined for <class 'neutron.cms.models.PageRoute'>
action 'metadata' in `policies.ACTION_POLICIES`
```

DRF sets `view.action = "metadata"` for **every** `OPTIONS` request on **every** ViewSet (see `rest_framework.viewsets.ViewSetMixin.initialize_request`). That action never has an entry in `ACTION_POLICIES`, so `has_global_permission` tripped its "no policy defined" assertion — surfacing as a 500 for ordinary traffic (CORS preflight follow-ups, endpoint introspection, vulnerability scanners).

## Why this wasn't already fixed

- **PR #36** addressed a *different* path — the queryset-less `DefaultRouter` root view via `_ignore_model_permissions` — and never touched this assertion.
- **Commit `ca14328`** tried to cover OPTIONS by carving out `action=None`, but DRF never passes `None` for OPTIONS; it passes the literal string `"metadata"`. So that guard never fired for a single real OPTIONS request, and the 500 kept happening.

Note: `"metadata"` is not a "fake" endpoint — it's DRF's implicit action for the `OPTIONS` HTTP method, present on every viewset. It's the only unpolicied action an external request can reach on a correctly-configured viewset (the URL selects the viewset/action-map and the method selects the action within it; anything unmapped becomes `action=None`, already handled).

## Fix

Treat framework-implicit actions (currently just `"metadata"`) as a clean **deny + warning log** instead of an assertion, in both `has_global_permission` and `has_object_permission` — mirroring the existing `action=None` handling that `ca14328` intended.

Behavior:
- No policy for `metadata` → **403** (deny) + warning log, instead of 500. Fail-closed, consistent with `permissible`'s design.
- Genuinely unknown actions (e.g. a developer-defined `@action` with a forgotten policy) → **still raise**, preserving the guardrail.
- An explicit `"metadata"` policy → **honored** (takes precedence), so a project can opt into `OPTIONS`/introspection per model with e.g. `"metadata": NO_RESTRICTION`.

## Tests

Verified end-to-end through the real `PermissiblePerms.has_permission` → `has_global_permission` path with `action="metadata"`: **before** — exact prod `AssertionError`; **after** — returns `False` (→ 403). Added unit tests covering deny+log, unknown-action-still-raises, explicit-policy-honored, and superuser. Full suite: **151 passed** (was 147).

## Docs

README updated to document the deny-by-default behavior and the per-model `"metadata"` opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEPM5MC8ApeXpGH3Z2uQaj)_