### PR TITLE
Release: merge develop into main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  pytest:
+    name: Run pytest
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.13']
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --extra guardian --group dev
+
+      - name: Run tests
+        run: uv run pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           enable-cache: true
           cache-dependency-glob: uv.lock
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,12 @@ on:
       - main
       - develop
 
+# Cancel superseded runs: a new push to the same branch/PR stops the
+# in-progress run instead of letting both finish.
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pytest:
     name: Run pytest
@@ -25,6 +31,8 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Install dependencies
         run: uv sync --extra guardian --group dev

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,11 +18,6 @@ jobs:
     name: Run pytest
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.12', '3.13']
-
     steps:
       - name: Check out code
         uses: actions/checkout@v6
@@ -30,7 +25,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.13'
           enable-cache: true
           cache-dependency-glob: uv.lock
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,27 @@ ACTION_POLICIES = {
 }
 ```
 
+Every action must have an explicit policy — if a request resolves to an action
+with no policy defined, permission is denied and an assertion is raised (a
+deliberate guardrail against forgetting to configure an action).
+
+The one exception is DRF's implicit `"metadata"` action, which DRF sets for
+every `OPTIONS` request on every ViewSet. It never corresponds to a policy, so
+it is **denied by default** (returning `403`, and logging a warning) rather than
+raising. If you want `OPTIONS`/introspection to work for a model, opt in by
+defining an explicit `"metadata"` policy for it, e.g.:
+```
+ACTION_POLICIES = {
+    "surveys.Survey": {
+        "global": {
+            ...
+            "metadata": NO_RESTRICTION,  # or IS_AUTHENTICATED, etc.
+        },
+        ...
+    }
+}
+```
+
 With the permissions configured, now we can force different views to use them:
 - If you would like the permissions to work for API views (via
 `django-rest-framework`): Add `PermissiblePerms` to the `permission_classes` for

--- a/permissible/models/permissible_mixin.py
+++ b/permissible/models/permissible_mixin.py
@@ -17,6 +17,12 @@ from .policy_lookup import PolicyLooupMixin
 logger = logging.getLogger(__name__)
 
 
+# DRF sets `view.action = "metadata"` for every OPTIONS request (see
+# ViewSetMixin.initialize_request). Such implicit actions never have a policy, so
+# a missing one must deny cleanly rather than trip the assertion below (a 500).
+DRF_IMPLICIT_ACTIONS = frozenset({"metadata"})
+
+
 class PermissibleMixin(PolicyLooupMixin, BasePermDefObj):
     """
     Model mixin that allows a model to check permissions, in accordance with
@@ -151,9 +157,20 @@ class PermissibleMixin(PolicyLooupMixin, BasePermDefObj):
             perm_def = cls.get_global_perms_def("retrieve")
 
         # Deny if no EXPLICIT permission check is defined
-        assert (
-            perm_def is not None
-        ), f"No global permission defined for {cls} action '{action}' in `policies.ACTION_POLICIES`"
+        if perm_def is None:
+            if action in DRF_IMPLICIT_ACTIONS:
+                logger.warning(
+                    "Denying implicit DRF action '%s' for %s (no policy defined; "
+                    "add one to ACTION_POLICIES to override).",
+                    action,
+                    cls,
+                )
+                return False
+
+            raise AssertionError(
+                f"No global permission defined for {cls} action '{action}' in "
+                f"`policies.ACTION_POLICIES`"
+            )
 
         # Check permissions on the class
         return perm_def.check_global(
@@ -204,9 +221,20 @@ class PermissibleMixin(PolicyLooupMixin, BasePermDefObj):
 
         # Get the PermDef for this action (object permissions)
         perm_def = self.get_object_perm_def(action)
-        assert (
-            perm_def is not None
-        ), f"No object permission for {self.__class__.__name__} (action '{action}') in `policies.ACTION_POLICIES`"
+        if perm_def is None:
+            if action in DRF_IMPLICIT_ACTIONS:
+                logger.warning(
+                    "Denying implicit DRF action '%s' for %s (no policy defined; "
+                    "add one to ACTION_POLICIES to override).",
+                    action,
+                    self.__class__,
+                )
+                return False
+
+            raise AssertionError(
+                f"No object permission for {self.__class__.__name__} "
+                f"(action '{action}') in `policies.ACTION_POLICIES`"
+            )
 
         # Check permissions on the object
         return perm_def.check_obj(

--- a/tests/test_permissible_mixin.py
+++ b/tests/test_permissible_mixin.py
@@ -292,6 +292,64 @@ class TestPermissibleMixin(unittest.TestCase):
         self.assertTrue(any("action=None" in msg for msg in cm.output))
 
     @patch("permissible.models.permissible_mixin.PolicyLooupMixin.get_policies")
+    def test_metadata_action_denies_and_logs(self, mock_get_policies):
+        """DRF's implicit "metadata" (OPTIONS) action denies + logs, not raises."""
+        mock_get_policies.return_value = self.test_model._policies
+
+        with self.assertLogs(
+            "permissible.models.permissible_mixin", level="WARNING"
+        ) as cm:
+            self.assertFalse(
+                TestModel.has_global_permission(self.view_user, "metadata"),
+                "metadata (OPTIONS) should deny, not raise",
+            )
+        self.assertTrue(any("metadata" in msg for msg in cm.output))
+
+        with self.assertLogs(
+            "permissible.models.permissible_mixin", level="WARNING"
+        ) as cm:
+            self.assertFalse(
+                self.test_model.has_object_permission(self.view_user, "metadata"),
+                "metadata (OPTIONS) should deny, not raise",
+            )
+        self.assertTrue(any("metadata" in msg for msg in cm.output))
+
+    @patch("permissible.models.permissible_mixin.PolicyLooupMixin.get_policies")
+    def test_unknown_action_still_raises(self, mock_get_policies):
+        """A non-implicit action with no policy still raises (the guardrail)."""
+        mock_get_policies.return_value = self.test_model._policies
+
+        with self.assertRaises(AssertionError):
+            TestModel.has_global_permission(self.view_user, "some_custom_action")
+
+        with self.assertRaises(AssertionError):
+            self.test_model.has_object_permission(self.view_user, "some_custom_action")
+
+    @patch("permissible.models.permissible_mixin.PolicyLooupMixin.get_policies")
+    def test_metadata_action_honors_explicit_policy(self, mock_get_policies):
+        """An explicit "metadata" policy wins over the deny-by-default carve-out."""
+        policies = {
+            "global": {**self.test_model._policies["global"], "metadata": p(["view"])},
+            "object": {**self.test_model._policies["object"], "metadata": p(["view"])},
+        }
+        mock_get_policies.return_value = policies
+
+        self.assertTrue(
+            TestModel.has_global_permission(self.view_user, "metadata"),
+            "An explicit metadata policy should be honored",
+        )
+
+    @patch("permissible.models.permissible_mixin.PolicyLooupMixin.get_policies")
+    def test_metadata_action_superuser(self, mock_get_policies):
+        """Superusers short-circuit before the policy lookup, even for metadata."""
+        mock_get_policies.return_value = self.test_model._policies
+
+        self.assertTrue(
+            TestModel.has_global_permission(self.superuser, "metadata"),
+            "Superuser should pass the metadata action",
+        )
+
+    @patch("permissible.models.permissible_mixin.PolicyLooupMixin.get_policies")
     def test_object_permissions_view_only(self, mock_get_policies):
         """Test that view-only users have appropriate object permissions"""
         mock_get_policies.return_value = self.test_model._policies


### PR DESCRIPTION
## Summary

Promotes the current `develop` branch to `main`. Merging this will trigger the release workflow (version bump + tag + PyPI publish).

## Changes included

**CI (#38)**
- New `.github/workflows/tests.yml` running the full pytest suite on pull requests and pushes to `main`/`develop`, on Python 3.12 (the minimum supported version), using `uv` with explicit caching and concurrency cancellation.

**Permissions fix (#37)**
- Deny (rather than 500) on DRF implicit `metadata`/`OPTIONS` actions.
- Documented the OPTIONS/metadata deny-by-default behavior and the per-model opt-in.

## Notes

- All commits on `develop` are already covered by the PRs above.
- The `Run pytest` check passed on `develop` before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeiUVrr73gVFNYphXSjBwC)_