### PR TITLE
Upgrade to Django 6 (>=6,<7), add admin test coverage

### DIFF
--- a/permissible/admin/forms.py
+++ b/permissible/admin/forms.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from django.contrib import admin
 from django.contrib.admin.widgets import AutocompleteSelect
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django import forms
 
 User = get_user_model()
@@ -166,7 +166,17 @@ class BaseRoleBasedForm(forms.Form):
 
         Uses django-guardian's permission system to verify the user has the
         specific 'change_permission' permission on the given object.
+
+        NOTE: `obj` must be a `PermissibleMixin` model. In particular, the
+        user-centric admin view (`UserPermDomainAdminMixin`) passes the target
+        User here, so the project's User model must include `PermissibleMixin`.
         """
+        if not hasattr(obj, "get_permission_codename"):
+            raise ImproperlyConfigured(
+                f"{obj.__class__.__name__} must use PermissibleMixin to be used "
+                "in permissible admin views. If this is your User model, it "
+                "must include PermissibleMixin to use UserPermDomainAdminMixin."
+            )
         permission = obj.get_permission_codename("change_permission", True)
         return user.has_perm(permission, obj)
 

--- a/permissible/admin/perm_domain.py
+++ b/permissible/admin/perm_domain.py
@@ -23,7 +23,7 @@ from django.http import Http404
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
-from django.utils.html import format_html
+from django.utils.html import format_html, format_html_join
 
 from .forms import PermDomainForm, BaseRoleBasedForm, UserPermDomainForm
 
@@ -325,4 +325,4 @@ class UserPermDomainAdminMixin(BasePermissibleViewMixin):
             )
         if not links:
             return "None"
-        return format_html(" | ".join(links))
+        return format_html_join(" | ", "{}", ((link,) for link in links))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,13 @@ description = "Extended, flexible and powerful object-level and rule-driven perm
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-  "Django>=5.2.13,<6",
-  "djangorestframework>=3",
+  "Django>=6,<7",
+  "djangorestframework>=3.17",  # 3.17.0 is the first release with official Django 6.0 support
 ]
 
 [project.optional-dependencies]
 guardian = [
-  "django-guardian==3.3.1",     # can be upgraded
+  "django-guardian==3.3.2",     # 3.3.3 breaks get_objects_for_user (UNION column mismatch) on all Django versions
   "djangorestframework-guardian"
 ]
 

--- a/tests/integration/test_perm_domain_integration.py
+++ b/tests/integration/test_perm_domain_integration.py
@@ -36,7 +36,7 @@ class TestIntegrationTeamModel(PermDomain):
     )
 
     class Meta:
-        app_label = "permissible"
+        app_label = "tests"
         permissions = (
             ("view_on_testintegrationteammodel", "Can view content in test team"),
         )
@@ -96,7 +96,7 @@ class TestTeamRole(PermDomainRole):
     role = build_role_field(ROLE_DEFINITIONS)
 
     class Meta:
-        app_label = "permissible"
+        app_label = "tests"
         unique_together = ("team", "role")
 
 
@@ -110,7 +110,7 @@ class TestTeamMember(PermDomainMember):
     )
 
     class Meta:
-        app_label = "permissible"
+        app_label = "tests"
         unique_together = ("team", "user")
 
 
@@ -127,7 +127,7 @@ class TestContent(PermissibleMixin, models.Model):
     )
 
     class Meta:
-        app_label = "permissible"
+        app_label = "tests"
 
     def __str__(self):
         return self.title

--- a/tests/integration/test_permissible_filter_integration.py
+++ b/tests/integration/test_permissible_filter_integration.py
@@ -27,7 +27,7 @@ class TestFilterIntegrationModel(PermissibleMixin, models.Model):
     owner = models.ForeignKey(get_user_model(), on_delete=models.CASCADE, null=True)
 
     class Meta:
-        app_label = "permissible"
+        app_label = "tests"
 
     def __str__(self):
         return self.name

--- a/tests/integration/test_permissible_perms_integration.py
+++ b/tests/integration/test_permissible_perms_integration.py
@@ -29,7 +29,7 @@ class TestPermIntegrationModel(PermissibleMixin, models.Model):
     owner = models.ForeignKey(get_user_model(), on_delete=models.CASCADE, null=True)
 
     class Meta:
-        app_label = "permissible"
+        app_label = "tests"
 
     def __str__(self):
         return self.name
@@ -120,7 +120,7 @@ class PermissiblePermsIntegrationTest(TestCase):
         assign_short_perms(["view", "change"], cls.owner_user, cls.owned_obj)
 
         # Assign global permissions
-        assign_perm("permissible.add_testpermintegrationmodel", cls.staff_user)
+        assign_perm("tests.add_testpermintegrationmodel", cls.staff_user)
 
         # Set up request factory
         cls.factory = APIRequestFactory()

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,6 @@
+"""
+This module must exist (even if empty) so that Django's test-database setup
+creates tables for models registered under the `tests` app: syncdb-style table
+creation skips apps whose `models_module` is None. Concrete test models are
+defined in the test modules themselves with `Meta.app_label = "tests"`.
+"""

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -25,6 +25,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "guardian",  # Required for object-level permissions
     "permissible",
+    "tests",  # Registered as an app so test models get their own app_label
 ]
 
 MIDDLEWARE = [
@@ -70,7 +71,6 @@ AUTH_PASSWORD_VALIDATORS = []
 LANGUAGE_CODE = "en-us"
 TIME_ZONE = "UTC"
 USE_I18N = True
-USE_L10N = True
 USE_TZ = True
 
 # Static files

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,291 @@
+"""
+Tests for the admin mixins in `permissible.admin`.
+
+Models here are registered under the `tests` app (see INSTALLED_APPS), so they
+don't need to share the `permissible` app registry with other test modules.
+"""
+
+from unittest.mock import patch
+
+from django.contrib import admin
+from django.contrib.auth import get_user_model
+from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.models import Group
+from django.core.exceptions import ImproperlyConfigured
+from django.db import models
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+
+from permissible.admin import (
+    PermDomainAdminMixin,
+    PermissibleAdminMixin,
+    UserPermDomainAdminMixin,
+)
+from permissible.models import PermDomain, PermDomainMember, PermDomainRole
+
+User = get_user_model()
+
+
+# Concrete models (module level, so they are registered before test DB setup)
+
+
+class AdminTeam(PermDomain):
+    name = models.CharField(max_length=100)
+
+    groups = models.ManyToManyField(
+        Group, through="AdminTeamRole", related_name="admin_teams"
+    )
+    users = models.ManyToManyField(
+        get_user_model(), through="AdminTeamMember", related_name="admin_teams"
+    )
+
+    class Meta:
+        app_label = "tests"
+
+    def __str__(self):
+        return self.name
+
+
+class AdminTeamRole(PermDomainRole):
+    team = models.ForeignKey(
+        AdminTeam, on_delete=models.CASCADE, related_name="team_roles"
+    )
+
+    class Meta:
+        app_label = "tests"
+        unique_together = ("team", "role")
+
+
+class AdminTeamMember(PermDomainMember):
+    team = models.ForeignKey(
+        AdminTeam, on_delete=models.CASCADE, related_name="team_members"
+    )
+
+    class Meta:
+        app_label = "tests"
+        unique_together = ("team", "user")
+
+
+class AdminOrg(PermDomain):
+    name = models.CharField(max_length=100)
+
+    groups = models.ManyToManyField(
+        Group, through="AdminOrgRole", related_name="admin_orgs"
+    )
+    users = models.ManyToManyField(
+        get_user_model(), through="AdminOrgMember", related_name="admin_orgs"
+    )
+
+    class Meta:
+        app_label = "tests"
+
+    def __str__(self):
+        return self.name
+
+
+class AdminOrgRole(PermDomainRole):
+    org = models.ForeignKey(
+        AdminOrg, on_delete=models.CASCADE, related_name="org_roles"
+    )
+
+    class Meta:
+        app_label = "tests"
+        unique_together = ("org", "role")
+
+
+class AdminOrgMember(PermDomainMember):
+    org = models.ForeignKey(
+        AdminOrg, on_delete=models.CASCADE, related_name="org_members"
+    )
+
+    class Meta:
+        app_label = "tests"
+        unique_together = ("org", "user")
+
+
+# Admin classes
+
+
+class AdminTeamAdmin(PermDomainAdminMixin, admin.ModelAdmin):
+    pass
+
+
+class AdminOrgAdmin(PermDomainAdminMixin, admin.ModelAdmin):
+    pass
+
+
+class PermissibleUserAdmin(UserPermDomainAdminMixin, UserAdmin):
+    domain_class_dict = {"team": AdminTeam, "org": AdminOrg}
+    readonly_fields = tuple(UserAdmin.readonly_fields) + ("permissible_groups_links",)
+    fieldsets = tuple(UserAdmin.fieldsets) + (
+        ("Permissible", {"fields": ("permissible_groups_links",)}),
+    )
+
+
+class EmptyDomainUserAdmin(UserPermDomainAdminMixin, admin.ModelAdmin):
+    domain_class_dict = {}
+
+
+class AdminTeamPermissibleAdmin(PermissibleAdminMixin, admin.ModelAdmin):
+    pass
+
+
+admin.site.register(AdminTeam, AdminTeamAdmin)
+admin.site.register(AdminOrg, AdminOrgAdmin)
+admin.site.unregister(User)
+admin.site.register(User, PermissibleUserAdmin)
+
+
+class AdminTestCaseBase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = User.objects.create_superuser(
+            username="admin", email="admin@example.com", password="pw"
+        )
+        cls.staff_user = User.objects.create_user(
+            username="staff", password="pw", is_staff=True
+        )
+        cls.plain_user = User.objects.create_user(username="plain", password="pw")
+        cls.team = AdminTeam.objects.create(name="Team A")
+        cls.org = AdminOrg.objects.create(name="Org A")
+
+
+class PermDomainAdminMixinTest(AdminTestCaseBase):
+    def setUp(self):
+        self.client.force_login(self.superuser)
+        self.team_admin = admin.site._registry[AdminTeam]
+
+    def test_get_urls_registers_permissible_route(self):
+        url = reverse("admin:tests_adminteam_permissible_change", args=[self.team.pk])
+        self.assertEqual(url, f"/admin/tests/adminteam/{self.team.pk}/permissible/")
+
+    def test_permissible_groups_link(self):
+        html = self.team_admin.permissible_groups_link(self.team)
+        self.assertIn(f"/admin/tests/adminteam/{self.team.pk}/permissible/", html)
+        self.assertIn("Edit permissible groups", html)
+
+    def test_change_page_renders_permissible_link(self):
+        response = self.client.get(
+            reverse("admin:tests_adminteam_change", args=[self.team.pk])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Edit permissible groups")
+
+    def test_permissible_view_get(self):
+        response = self.client.get(
+            reverse("admin:tests_adminteam_permissible_change", args=[self.team.pk])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "admin/permissible_changeform.html")
+
+    def test_permissible_view_post_redirects(self):
+        url = reverse("admin:tests_adminteam_permissible_change", args=[self.team.pk])
+        response = self.client.post(url, data={})
+        self.assertRedirects(response, url)
+
+    def test_permissible_view_requires_change_permission(self):
+        self.client.force_login(self.staff_user)
+        response = self.client.get(
+            reverse("admin:tests_adminteam_permissible_change", args=[self.team.pk])
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_reset_domain_roles_action(self):
+        expected_roles = len(AdminTeamRole.ROLE_DEFINITIONS)
+        self.assertEqual(
+            AdminTeamRole.objects.filter(team=self.team).count(), expected_roles
+        )
+        AdminTeamRole.objects.filter(team=self.team).delete()
+        self.assertEqual(AdminTeamRole.objects.filter(team=self.team).count(), 0)
+
+        self.team_admin.reset_domain_roles(
+            request=None, queryset=AdminTeam.objects.filter(pk=self.team.pk)
+        )
+        self.assertEqual(
+            AdminTeamRole.objects.filter(team=self.team).count(), expected_roles
+        )
+
+
+class UserPermDomainAdminMixinTest(AdminTestCaseBase):
+    def setUp(self):
+        self.client.force_login(self.superuser)
+        self.user_admin = admin.site._registry[User]
+
+    def test_get_urls_registers_route_per_domain_type(self):
+        for perm_type in ("team", "org"):
+            url = reverse(
+                f"admin:auth_user_permissible_{perm_type}", args=[self.plain_user.pk]
+            )
+            self.assertEqual(
+                url, f"/admin/auth/user/{self.plain_user.pk}/permissible/{perm_type}/"
+            )
+
+    def test_permissible_groups_links_joins_all_domain_types(self):
+        # Regression test for Django 6.0: this called format_html() without
+        # args, which raises TypeError on Django >= 6.0.
+        html = self.user_admin.permissible_groups_links(self.plain_user)
+        self.assertIn("Edit team permissions", html)
+        self.assertIn("Edit org permissions", html)
+        self.assertIn(" | ", html)
+
+    def test_permissible_groups_links_empty_dict(self):
+        empty_admin = EmptyDomainUserAdmin(User, admin.site)
+        self.assertEqual(empty_admin.permissible_groups_links(self.plain_user), "None")
+
+    def test_user_change_page_renders_links(self):
+        response = self.client.get(
+            reverse("admin:auth_user_change", args=[self.plain_user.pk])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Edit team permissions")
+        self.assertContains(response, "Edit org permissions")
+
+    def test_user_permissible_view_requires_permissible_user_model(self):
+        # The user-centric view checks change_permission on the target User,
+        # which requires the User model to include PermissibleMixin. With
+        # vanilla auth.User it raises a clear configuration error.
+        url = reverse("admin:auth_user_permissible_team", args=[self.plain_user.pk])
+        with self.assertRaisesMessage(ImproperlyConfigured, "PermissibleMixin"):
+            self.client.get(url)
+        with self.assertRaisesMessage(ImproperlyConfigured, "PermissibleMixin"):
+            self.client.post(url, data={})
+
+
+class PermissibleAdminMixinTest(AdminTestCaseBase):
+    def setUp(self):
+        self.model_admin = AdminTeamPermissibleAdmin(AdminTeam, admin.site)
+        self.request = RequestFactory().get("/")
+        self.request.user = self.superuser
+
+    def test_has_change_permission_delegates_to_object(self):
+        with patch.object(
+            AdminTeam, "has_object_permission", return_value=True
+        ) as mock_check:
+            self.assertTrue(
+                self.model_admin.has_change_permission(self.request, obj=self.team)
+            )
+        self.assertEqual(mock_check.call_count, 1)
+        self.assertEqual(mock_check.call_args.kwargs["action"], "update")
+
+    def test_has_delete_permission_delegates_to_object(self):
+        with patch.object(
+            AdminTeam, "has_object_permission", return_value=False
+        ) as mock_check:
+            self.assertFalse(
+                self.model_admin.has_delete_permission(self.request, obj=self.team)
+            )
+        self.assertEqual(mock_check.call_args.kwargs["action"], "destroy")
+
+    def test_has_view_permission_falls_back_to_update(self):
+        with patch.object(
+            AdminTeam,
+            "has_object_permission",
+            side_effect=lambda **kwargs: kwargs["action"] == "update",
+        ):
+            self.assertTrue(
+                self.model_admin.has_view_permission(self.request, obj=self.team)
+            )
+
+    def test_has_add_permission_denied_globally(self):
+        with patch.object(AdminTeam, "has_global_permission", return_value=False):
+            self.assertFalse(self.model_admin.has_add_permission(self.request))

--- a/tests/test_bulk_update_permissions.py
+++ b/tests/test_bulk_update_permissions.py
@@ -37,7 +37,7 @@ class BulkTestDomain(PermDomain):
     )
 
     class Meta:
-        app_label = "permissible"
+        app_label = "tests"
         abstract = False
 
     def __str__(self):
@@ -60,7 +60,7 @@ class BulkTestDomainRole(PermDomainRole):
     )
 
     class Meta:
-        app_label = "permissible"
+        app_label = "tests"
         abstract = False
 
 
@@ -74,7 +74,7 @@ class BulkTestDomainMember(PermDomainMember):
     )
 
     class Meta:
-        app_label = "permissible"
+        app_label = "tests"
         abstract = False
         unique_together = ("bulktestdomain", "user")
 

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -22,7 +22,7 @@ class TestLoggingModel(PermissibleMixin, models.Model):
     name = models.CharField(max_length=100)
 
     class Meta:
-        app_label = "permissible"
+        app_label = "tests"
 
     @classmethod
     def get_policies(cls):

--- a/tests/test_hierarchical_perm_domain.py
+++ b/tests/test_hierarchical_perm_domain.py
@@ -30,7 +30,7 @@ class DummyHierarchicalDomain(HierarchicalPermDomain):
         return self.name
 
     class Meta:
-        app_label = "permissible"  # Ensure proper app_label for testing
+        app_label = "tests"  # Ensure proper app_label for testing
 
 
 # Define a dummy domain role model that links DummyHierarchicalDomain to roles
@@ -54,7 +54,7 @@ class DummyHierarchicalDomainRole(PermDomainRole):
     )
 
     class Meta:
-        app_label = "permissible"
+        app_label = "tests"
         # Group and domain together must be unique
         unique_together = ("group", "domain")
 
@@ -71,7 +71,7 @@ class DummyHierarchicalDomainMember(PermDomainMember):
     )
 
     class Meta:
-        app_label = "permissible"
+        app_label = "tests"
 
 
 class HierarchicalPermDomainTests(TestCase):

--- a/tests/test_perm_domain.py
+++ b/tests/test_perm_domain.py
@@ -35,7 +35,7 @@ class DummyDomain(PermDomain):
     )
 
     class Meta:
-        app_label = "permissible"  # Add explicit app_label
+        app_label = "tests"  # Add explicit app_label
         abstract = False
 
     def __str__(self):
@@ -62,9 +62,7 @@ class DummyDomainRole(PermDomainRole):
     )
 
     class Meta:
-        app_label = (
-            "permissible"  # Necessary since our abstract models have no app_label.
-        )
+        app_label = "tests"  # Necessary since our abstract models have no app_label.
         abstract = False
 
 
@@ -78,7 +76,7 @@ class DummyDomainMember(PermDomainMember):
     )
 
     class Meta:
-        app_label = "permissible"
+        app_label = "tests"
         abstract = False
         # Add a unique constraint for the domain and user
         unique_together = ("dummydomain", "user")  # Add this line

--- a/uv.lock
+++ b/uv.lock
@@ -22,41 +22,41 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.13"
+version = "6.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/c5/c69e338eb2959f641045802e5ea87ca4bf5ac90c5fd08953ca10742fad51/django-5.2.13.tar.gz", hash = "sha256:a31589db5188d074c63f0945c3888fad104627dfcc236fb2b97f71f89da33bc4", size = 10890368, upload-time = "2026-04-07T14:02:15.072Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/55/664f24ff81c9ea19cb7dfc851afeae1f3c2390c7aee01d4ded68b5c1580d/django-6.0.7.tar.gz", hash = "sha256:2998503fc083124fb58037084bfa00de323c7c743f05f1b4284e77bff0ab8890", size = 10921299, upload-time = "2026-07-07T13:51:26.485Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/b1/51ab36b2eefcf8cdb9338c7188668a157e29e30306bfc98a379704c9e10d/django-5.2.13-py3-none-any.whl", hash = "sha256:5788fce61da23788a8ce6f02583765ab060d396720924789f97fa42119d37f7a", size = 8310982, upload-time = "2026-04-07T14:02:08.883Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ec/1ce5334b6a2c52ce619c23a0be8d366a57a0e080ebb2d88266e5c849157c/django-6.0.7-py3-none-any.whl", hash = "sha256:a037427c2288443a8c02a1b02295a31c239663aa682bc50b1976afb7cf6a769e", size = 8373344, upload-time = "2026-07-07T13:51:20.007Z" },
 ]
 
 [[package]]
 name = "django-guardian"
-version = "3.3.1"
+version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/9a/e332f886bc38dd8bb7b0cdf7305d8dcf6acc376459b87b1ce73697666d55/django_guardian-3.3.1.tar.gz", hash = "sha256:7a50eada72161e355a9dbf9fe0838855c0ec851dd9b39f4f16e2decb5f4c7988", size = 109557, upload-time = "2026-03-30T09:44:59.008Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/89/0b0b268b158cd9155c1b49ebd1429a186228af359c84ab6fd74ecea572e4/django_guardian-3.3.2.tar.gz", hash = "sha256:f8edcf1576eb15d1593e23955693723ef351a7340667f9159e7bec786559c1ab", size = 110499, upload-time = "2026-06-08T12:02:39.643Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/4f/f798f8a2cb2f84def1fd2bf38f497c45a2ebd093f6bdb1f349eb52faa466/django_guardian-3.3.1-py3-none-any.whl", hash = "sha256:2a3a4b94cdc7e8fc99b74eef163db69d17703dc397c3e9085c7231f2b2bcf431", size = 146125, upload-time = "2026-03-30T09:44:57.599Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/80/5d3793ee277968dcc0c7e8a7752c9dc51d0fec632d9ab12229fa89172846/django_guardian-3.3.2-py3-none-any.whl", hash = "sha256:d5245d6be77a6c632f5b0c739221a44e6469dfa4925c75653ea49cec388e6765", size = 146962, upload-time = "2026-06-08T12:02:38.21Z" },
 ]
 
 [[package]]
 name = "djangorestframework"
-version = "3.16.1"
+version = "3.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/95/5376fe618646fde6899b3cdc85fd959716bb67542e273a76a80d9f326f27/djangorestframework-3.16.1.tar.gz", hash = "sha256:166809528b1aced0a17dc66c24492af18049f2c9420dbd0be29422029cfc3ff7", size = 1089735, upload-time = "2025-08-06T17:50:53.251Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/d7/c016e69fac19ff8afdc89db9d31d9ae43ae031e4d1993b20aca179b8301a/djangorestframework-3.17.1.tar.gz", hash = "sha256:a6def5f447fe78ff853bff1d47a3c59bf38f5434b031780b351b0c73a62db1a5", size = 905742, upload-time = "2026-03-24T16:58:33.705Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/ce/bf8b9d3f415be4ac5588545b5fcdbbb841977db1c1d923f7568eeabe1689/djangorestframework-3.16.1-py3-none-any.whl", hash = "sha256:33a59f47fb9c85ede792cbf88bde71893bcda0667bc573f784649521f1102cec", size = 1080442, upload-time = "2025-08-06T17:50:50.667Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e1/2c516bdc83652b1a60c6119366ac2c0607b479ed05cd6093f916ca8928f8/djangorestframework-3.17.1-py3-none-any.whl", hash = "sha256:c3c74dd3e83a5a3efc37b3c18d92bd6f86a6791c7b7d4dff62bb068500e76457", size = 898844, upload-time = "2026-03-24T16:58:31.845Z" },
 ]
 
 [[package]]
@@ -115,9 +115,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=5.2.13,<6" },
-    { name = "django-guardian", marker = "extra == 'guardian'", specifier = "==3.3.1" },
-    { name = "djangorestframework", specifier = ">=3" },
+    { name = "django", specifier = ">=6,<7" },
+    { name = "django-guardian", marker = "extra == 'guardian'", specifier = "==3.3.2" },
+    { name = "djangorestframework", specifier = ">=3.17" },
     { name = "djangorestframework-guardian", marker = "extra == 'guardian'" },
 ]
 provides-extras = ["guardian"]


### PR DESCRIPTION
## Summary
- **Django constraint → `>=6,<7`** (drops Django 5.x support); lock resolves Django 6.0.7
- **DRF → `>=3.17`** — 3.17.0 is the first release with official Django 6.0 support (locked: 3.17.1)
- **django-guardian pinned to `3.3.2`** — 3.3.3 has a `get_objects_for_user` UNION-column regression that breaks 3 integration tests on *all* Django versions (its "bigint cast" fix); 3.3.2 is fully green on Django 6
- **Fix the one real Django 6.0 break**: `UserPermDomainAdminMixin.permissible_groups_links` called `format_html()` with no args, which 6.0 turns into a hard `TypeError` on every UserAdmin change page — now uses `format_html_join`
- **Clear error instead of crash**: permission checks on objects without `PermissibleMixin` (e.g. vanilla `auth.User` in the user-centric admin view) now raise `ImproperlyConfigured` explaining the mixin requirement, instead of an opaque `AttributeError`
- **New admin test coverage** (`tests/test_admin.py`, 16 tests): the admin mixins previously had zero tests, which is exactly where the Django 6 break was hiding
- **Test app registry cleanup**: `tests` is now its own Django app; all concrete test models moved from `app_label = "permissible"` to `app_label = "tests"`
- Drop dead `USE_L10N` test setting (removed in Django 5.0)

## Test plan
- Full suite: **167 passed** on Python 3.12 and 3.13 (CI matrix), also green with `-W error::DeprecationWarning -W error::PendingDeprecationWarning`
- Ruff lint + format check clean (same commands as CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)